### PR TITLE
Implement admin commands for points

### DIFF
--- a/src/main/java/ch/ksrminecraft/akzuwoRankAPIPlaceholder/AkzuwoExtensionCommand.java
+++ b/src/main/java/ch/ksrminecraft/akzuwoRankAPIPlaceholder/AkzuwoExtensionCommand.java
@@ -1,0 +1,102 @@
+package ch.ksrminecraft.akzuwoRankAPIPlaceholder;
+
+import ch.ksrminecraft.akzuwoRankAPIPlaceholder.utils.RankAPI;
+import com.velocitypowered.api.command.SimpleCommand;
+import com.velocitypowered.api.proxy.Player;
+import com.velocitypowered.api.proxy.ProxyServer;
+import net.kyori.adventure.text.Component;
+
+import java.util.Optional;
+
+public class AkzuwoExtensionCommand implements SimpleCommand {
+
+    private final ProxyServer server;
+    private final RankAPI api;
+
+    public AkzuwoExtensionCommand(ProxyServer server, RankAPI api) {
+        this.server = server;
+        this.api = api;
+    }
+
+    @Override
+    public boolean hasPermission(Invocation invocation) {
+        return invocation.source().hasPermission("akzuwoextension.admin");
+    }
+
+    @Override
+    public void execute(Invocation invocation) {
+        String[] args = invocation.arguments().split(" ");
+        if (args.length == 0 || args[0].isEmpty()) {
+            invocation.source().sendMessage(Component.text("Usage: /akzuwoextension <setpoints|addpoints|getpoints> <player> [points]"));
+            return;
+        }
+
+        String sub = args[0].toLowerCase();
+        switch (sub) {
+            case "setpoints":
+                if (args.length < 3) {
+                    invocation.source().sendMessage(Component.text("Usage: /akzuwoextension setpoints <player> <points>"));
+                    return;
+                }
+                handleSet(invocation, args[1], args[2]);
+                break;
+            case "addpoints":
+                if (args.length < 3) {
+                    invocation.source().sendMessage(Component.text("Usage: /akzuwoextension addpoints <player> <points>"));
+                    return;
+                }
+                handleAdd(invocation, args[1], args[2]);
+                break;
+            case "getpoints":
+                if (args.length < 2) {
+                    invocation.source().sendMessage(Component.text("Usage: /akzuwoextension getpoints <player>"));
+                    return;
+                }
+                handleGet(invocation, args[1]);
+                break;
+            default:
+                invocation.source().sendMessage(Component.text("Unknown subcommand."));
+                break;
+        }
+    }
+
+    private void handleSet(Invocation invocation, String playerName, String value) {
+        Optional<Player> opt = server.getPlayer(playerName);
+        if (opt.isEmpty()) {
+            invocation.source().sendMessage(Component.text("Player not found"));
+            return;
+        }
+        try {
+            int points = Integer.parseInt(value);
+            api.setPoints(opt.get().getUniqueId(), points);
+            invocation.source().sendMessage(Component.text("Set points for " + playerName + " to " + points));
+        } catch (NumberFormatException ex) {
+            invocation.source().sendMessage(Component.text("Invalid number"));
+        }
+    }
+
+    private void handleAdd(Invocation invocation, String playerName, String value) {
+        Optional<Player> opt = server.getPlayer(playerName);
+        if (opt.isEmpty()) {
+            invocation.source().sendMessage(Component.text("Player not found"));
+            return;
+        }
+        try {
+            int delta = Integer.parseInt(value);
+            api.addPoints(opt.get().getUniqueId(), delta);
+            invocation.source().sendMessage(Component.text("Added " + delta + " points to " + playerName));
+        } catch (NumberFormatException ex) {
+            invocation.source().sendMessage(Component.text("Invalid number"));
+        }
+    }
+
+    private void handleGet(Invocation invocation, String playerName) {
+        Optional<Player> opt = server.getPlayer(playerName);
+        if (opt.isEmpty()) {
+            invocation.source().sendMessage(Component.text("Player not found"));
+            return;
+        }
+        int points = api.getPoints(opt.get().getUniqueId());
+        invocation.source().sendMessage(Component.text(playerName + " has " + points + " points"));
+    }
+}

--- a/src/main/java/ch/ksrminecraft/akzuwoRankAPIPlaceholder/AkzuwoRankAPIPlaceholder.java
+++ b/src/main/java/ch/ksrminecraft/akzuwoRankAPIPlaceholder/AkzuwoRankAPIPlaceholder.java
@@ -9,6 +9,7 @@ import com.velocitypowered.api.plugin.annotation.DataDirectory;
 import com.velocitypowered.api.proxy.ProxyServer;
 import net.william278.papiproxybridge.api.PlaceholderAPI;
 import net.william278.papiproxybridge.api.PlaceholderSupplier;
+import com.velocitypowered.api.command.CommandManager;
 import org.slf4j.Logger;
 
 import java.nio.file.Files;
@@ -49,6 +50,14 @@ public class AkzuwoRankAPIPlaceholder {
                 return String.valueOf(rankAPI.getPoints(uuid));
             }
         });
+
+        if (rankAPI.isCommandsEnabled()) {
+            CommandManager manager = server.getCommandManager();
+            manager.register(
+                    manager.metaBuilder("akzuwoextension").plugin(this).build(),
+                    new AkzuwoExtensionCommand(server, rankAPI)
+            );
+        }
 
         logger.info("AkzuwoRankAPIPlaceholder loaded");
     }

--- a/src/main/java/ch/ksrminecraft/akzuwoRankAPIPlaceholder/utils/RankAPI.java
+++ b/src/main/java/ch/ksrminecraft/akzuwoRankAPIPlaceholder/utils/RankAPI.java
@@ -12,6 +12,7 @@ import java.util.UUID;
 
 public class RankAPI {
     private final PointsAPI api;
+    private final boolean commandsEnabled;
 
     public RankAPI(Path dataDirectory, Logger logger) throws Exception {
         Path configFile = dataDirectory.resolve("config.yml");
@@ -36,9 +37,22 @@ public class RankAPI {
         boolean debug = Boolean.parseBoolean(String.valueOf(db.getOrDefault("debug", false)));
 
         this.api = new PointsAPI(url, username, password, logger, debug);
+        this.commandsEnabled = Boolean.parseBoolean(String.valueOf(config.getOrDefault("commands", true)));
     }
 
     public int getPoints(UUID uuid) {
         return api.getPoints(uuid);
+    }
+
+    public void addPoints(UUID uuid, int delta) {
+        api.addPoints(uuid, delta);
+    }
+
+    public void setPoints(UUID uuid, int points) {
+        api.setPoints(uuid, points);
+    }
+
+    public boolean isCommandsEnabled() {
+        return commandsEnabled;
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -3,3 +3,4 @@ database:
   username: "username"
   password: "password"
   debug: true
+commands: true


### PR DESCRIPTION
## Summary
- add default commands config
- expose add/set points in RankAPI and expose config flag
- register `/akzuwoextension` command when enabled
- implement command class with get/add/set subcommands

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact org.codehaus.mojo:templating-maven-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_685164fdaf5c83258be1740ce563ac94