### PR TITLE
Remove PAPIProxyBridge placeholder

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,12 +169,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>net.william278</groupId>
-            <artifactId>papiproxybridge</artifactId>
-            <version>1.8.1</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>com.github.Samhuwsluz</groupId>
             <artifactId>RankPointsAPI</artifactId>
             <version>v0.1.5</version>

--- a/src/main/java/ch/ksrminecraft/akzuwoRankAPIPlaceholder/AkzuwoRankAPIPlaceholder.java
+++ b/src/main/java/ch/ksrminecraft/akzuwoRankAPIPlaceholder/AkzuwoRankAPIPlaceholder.java
@@ -6,15 +6,12 @@ import com.velocitypowered.api.event.Subscribe;
 import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
 import com.velocitypowered.api.plugin.Plugin;
 import com.velocitypowered.api.plugin.annotation.DataDirectory;
-import net.william278.papiproxybridge.api.PlaceholderSupplier;
 import com.velocitypowered.api.proxy.ProxyServer;
-import net.william278.papiproxybridge.api.PlaceholderAPI;
 import com.velocitypowered.api.command.CommandManager;
 import org.slf4j.Logger;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.UUID;
 
 @Plugin(id = "akzuwoextension", name = "AkzuwoRankAPIPlaceholder", version = "1.0")
 public class AkzuwoRankAPIPlaceholder {
@@ -43,13 +40,7 @@ public class AkzuwoRankAPIPlaceholder {
             return;
         }
 
-        // Register placeholder with PAPIProxyBridge
-        PlaceholderAPI.getInstance().registerPlaceholder("akzuwoextension_points", new PlaceholderSupplier() {
-            @Override
-            public String onRequest(UUID uuid) {
-                return String.valueOf(rankAPI.getPoints(uuid));
-            }
-        });
+
 
         if (rankAPI.isCommandsEnabled()) {
             CommandManager manager = server.getCommandManager();

--- a/src/main/resources/velocity-plugin.json
+++ b/src/main/resources/velocity-plugin.json
@@ -3,10 +3,5 @@
   "name": "AkzuwoRankAPIPlaceholder",
   "version": "${project.version}",
   "main": "ch.ksrminecraft.akzuwoRankAPIPlaceholder.AkzuwoRankAPIPlaceholder",
-  "dependencies": [
-    {
-      "id": "papiproxybridge",
-      "optional": true
-    }
-  ]
+  "dependencies": []
 }


### PR DESCRIPTION
## Summary
- remove PAPIProxyBridge placeholder registration
- drop papiproxybridge dependency from pom
- drop papiproxybridge optional dependency from `velocity-plugin.json`

## Testing
- `mvn -q -DskipTests=true package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68518c1248c48325872e33a0f311d8e8