### PR TITLE
Add Paper support and placeholder

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,6 +159,10 @@
             <id>jitpack.io</id>
             <url>https://jitpack.io</url>
         </repository>
+        <repository>
+            <id>papermc</id>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -177,6 +181,18 @@
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
             <version>2.2</version>
+        </dependency>
+        <dependency>
+            <groupId>io.papermc.paper</groupId>
+            <artifactId>paper-api</artifactId>
+            <version>1.20.4-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>me.clip</groupId>
+            <artifactId>placeholderapi</artifactId>
+            <version>2.11.5</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/ch/ksrminecraft/akzuwoRankAPIPlaceholder/paper/AkzuwoRankAPIPaper.java
+++ b/src/main/java/ch/ksrminecraft/akzuwoRankAPIPlaceholder/paper/AkzuwoRankAPIPaper.java
@@ -1,0 +1,38 @@
+package ch.ksrminecraft.akzuwoRankAPIPlaceholder.paper;
+
+import ch.ksrminecraft.akzuwoRankAPIPlaceholder.utils.RankAPI;
+import me.clip.placeholderapi.PlaceholderAPI;
+import me.clip.placeholderapi.expansion.PlaceholderExpansion;
+import org.bukkit.Bukkit;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AkzuwoRankAPIPaper extends JavaPlugin {
+
+    private RankAPI rankAPI;
+    private Logger logger;
+
+    @Override
+    public void onEnable() {
+        saveDefaultConfig();
+        logger = LoggerFactory.getLogger(getLogger().getName());
+        try {
+            rankAPI = new RankAPI(getDataFolder().toPath(), logger);
+        } catch (Exception e) {
+            getLogger().severe("Failed to load config: " + e.getMessage());
+            Bukkit.getPluginManager().disablePlugin(this);
+            return;
+        }
+
+        if (Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI")) {
+            new AkzuwoRankPlaceholder(this, rankAPI).register();
+        } else {
+            getLogger().warning("PlaceholderAPI not found, placeholder will not work");
+        }
+    }
+
+    public RankAPI getRankAPI() {
+        return rankAPI;
+    }
+}

--- a/src/main/java/ch/ksrminecraft/akzuwoRankAPIPlaceholder/paper/AkzuwoRankPlaceholder.java
+++ b/src/main/java/ch/ksrminecraft/akzuwoRankAPIPlaceholder/paper/AkzuwoRankPlaceholder.java
@@ -1,0 +1,47 @@
+package ch.ksrminecraft.akzuwoRankAPIPlaceholder.paper;
+
+import ch.ksrminecraft.akzuwoRankAPIPlaceholder.utils.RankAPI;
+import me.clip.placeholderapi.expansion.PlaceholderExpansion;
+import org.bukkit.entity.Player;
+
+public class AkzuwoRankPlaceholder extends PlaceholderExpansion {
+
+    private final AkzuwoRankAPIPaper plugin;
+    private final RankAPI api;
+
+    public AkzuwoRankPlaceholder(AkzuwoRankAPIPaper plugin, RankAPI api) {
+        this.plugin = plugin;
+        this.api = api;
+    }
+
+    @Override
+    public String getIdentifier() {
+        return "akzuwoextension";
+    }
+
+    @Override
+    public String getAuthor() {
+        return String.join(", ", plugin.getDescription().getAuthors());
+    }
+
+    @Override
+    public String getVersion() {
+        return plugin.getDescription().getVersion();
+    }
+
+    @Override
+    public boolean persist() {
+        return true;
+    }
+
+    @Override
+    public String onPlaceholderRequest(Player player, String identifier) {
+        if (player == null) {
+            return "";
+        }
+        if (identifier.equalsIgnoreCase("rankpoints")) {
+            return String.valueOf(api.getPoints(player.getUniqueId()));
+        }
+        return null;
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,0 +1,6 @@
+name: AkzuwoRankAPIPlaceholder
+main: ch.ksrminecraft.akzuwoRankAPIPlaceholder.paper.AkzuwoRankAPIPaper
+version: ${project.version}
+api-version: 1.20
+load: POSTWORLD
+depend: [PlaceholderAPI]


### PR DESCRIPTION
## Summary
- add Paper implementation alongside Velocity code
- register PlaceholderAPI placeholder `%akzuwoextension_rankpoints%`
- update `plugin.yml`
- include Paper dependencies and repository in `pom.xml`

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68519690bb7483258dde3d4c04b5c2f9