### PR TITLE
Add extension recommendation and tab completion

### DIFF
--- a/paper/src/main/java/ch/ksrminecraft/akzuwoRankAPIPlaceholder/paper/AkzuwoRankAPIPaper.java
+++ b/paper/src/main/java/ch/ksrminecraft/akzuwoRankAPIPlaceholder/paper/AkzuwoRankAPIPaper.java
@@ -4,6 +4,8 @@ import ch.ksrminecraft.akzuwoRankAPIPlaceholder.utils.RankAPI;
 import me.clip.placeholderapi.PlaceholderAPI;
 import me.clip.placeholderapi.expansion.PlaceholderExpansion;
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -12,6 +14,7 @@ public class AkzuwoRankAPIPaper extends JavaPlugin {
 
     private RankAPI rankAPI;
     private Logger logger;
+    private int announceTask;
 
     @Override
     public void onEnable() {
@@ -30,9 +33,25 @@ public class AkzuwoRankAPIPaper extends JavaPlugin {
         } else {
             getLogger().warning("PlaceholderAPI not found, placeholder will not work");
         }
+
+        Plugin ext = Bukkit.getPluginManager().getPlugin("AkzuwoExtension");
+        if (ext != null && ext.isEnabled()) {
+            getLogger().info("AkzuwoExtension gefunden");
+        }
+
+        long interval = 20L * 60 * 10; // 10 minutes
+        announceTask = Bukkit.getScheduler().scheduleSyncRepeatingTask(this,
+                () -> Bukkit.broadcastMessage(ChatColor.YELLOW +
+                        "Wir empfehlen die Verwendung des Plugins AkzuwoExtension!"),
+                interval, interval);
     }
 
     public RankAPI getRankAPI() {
         return rankAPI;
+    }
+
+    @Override
+    public void onDisable() {
+        Bukkit.getScheduler().cancelTask(announceTask);
     }
 }

--- a/velocity/src/main/java/ch/ksrminecraft/akzuwoRankAPIPlaceholder/AkzuwoExtensionCommand.java
+++ b/velocity/src/main/java/ch/ksrminecraft/akzuwoRankAPIPlaceholder/AkzuwoExtensionCommand.java
@@ -6,6 +6,11 @@ import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.ProxyServer;
 import net.kyori.adventure.text.Component;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import java.util.Optional;
 
 public class AkzuwoExtensionCommand implements SimpleCommand {
@@ -58,6 +63,30 @@ public class AkzuwoExtensionCommand implements SimpleCommand {
                 invocation.source().sendMessage(Component.text("Unknown subcommand."));
                 break;
         }
+    }
+
+    @Override
+    public List<String> suggest(Invocation invocation) {
+        String[] args = invocation.arguments();
+        if (args.length == 0) {
+            return Arrays.asList("setpoints", "addpoints", "getpoints");
+        }
+
+        if (args.length == 1) {
+            return Arrays.asList("setpoints", "addpoints", "getpoints").stream()
+                    .filter(s -> s.startsWith(args[0].toLowerCase()))
+                    .collect(Collectors.toList());
+        }
+
+        if (args.length == 2 && Arrays.asList("setpoints", "addpoints", "getpoints")
+                .contains(args[0].toLowerCase())) {
+            return server.getAllPlayers().stream()
+                    .map(Player::getUsername)
+                    .filter(n -> n.toLowerCase().startsWith(args[1].toLowerCase()))
+                    .collect(Collectors.toList());
+        }
+
+        return Collections.emptyList();
     }
 
     private void handleSet(Invocation invocation, String playerName, String value) {

--- a/velocity/src/main/java/ch/ksrminecraft/akzuwoRankAPIPlaceholder/AkzuwoRankAPIPlaceholder.java
+++ b/velocity/src/main/java/ch/ksrminecraft/akzuwoRankAPIPlaceholder/AkzuwoRankAPIPlaceholder.java
@@ -2,13 +2,14 @@ package ch.ksrminecraft.akzuwoRankAPIPlaceholder;
 
 import ch.ksrminecraft.akzuwoRankAPIPlaceholder.utils.RankAPI;
 import com.google.inject.Inject;
+import com.velocitypowered.api.command.CommandManager;
 import com.velocitypowered.api.event.Subscribe;
 import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
 import com.velocitypowered.api.plugin.Plugin;
 import com.velocitypowered.api.plugin.annotation.DataDirectory;
 import com.velocitypowered.api.proxy.ProxyServer;
-import com.velocitypowered.api.command.CommandManager;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -17,14 +18,13 @@ import java.nio.file.Path;
 public class AkzuwoRankAPIPlaceholder {
 
     private final ProxyServer server;
-    private final Logger logger;
     private final Path dataDirectory;
+    private final Logger logger = LoggerFactory.getLogger(AkzuwoRankAPIPlaceholder.class);
     private RankAPI rankAPI;
 
     @Inject
-    public AkzuwoRankAPIPlaceholder(ProxyServer server, Logger logger, @DataDirectory Path dataDirectory) {
+    public AkzuwoRankAPIPlaceholder(ProxyServer server, @DataDirectory Path dataDirectory) {
         this.server = server;
-        this.logger = logger;
         this.dataDirectory = dataDirectory;
     }
 


### PR DESCRIPTION
## Summary
- broadcast AkzuwoExtension reminder every 10 minutes on Paper
- log once if AkzuwoExtension is installed
- add tab completion for Velocity command

## Testing
- `mvn -q -pl velocity -am package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68519cf9b4b08325823fd53982e2b029