### PR TITLE
Fix logger initialization

### DIFF
--- a/common/src/main/java/ch/ksrminecraft/akzuwoRankAPIPlaceholder/utils/RankAPI.java
+++ b/common/src/main/java/ch/ksrminecraft/akzuwoRankAPIPlaceholder/utils/RankAPI.java
@@ -13,8 +13,10 @@ import java.util.UUID;
 public class RankAPI {
     private final PointsAPI api;
     private final boolean commandsEnabled;
+    private final Logger logger;
 
     public RankAPI(Path dataDirectory, Logger logger) throws Exception {
+        this.logger = logger;
         Path configFile = dataDirectory.resolve("config.yml");
         if (Files.notExists(configFile)) {
             try (InputStream in = RankAPI.class.getClassLoader().getResourceAsStream("config.yml")) {
@@ -36,7 +38,7 @@ public class RankAPI {
         String password = (String) db.get("password");
         boolean debug = Boolean.parseBoolean(String.valueOf(db.getOrDefault("debug", false)));
 
-        java.util.logging.Logger julLogger = java.util.logging.Logger.getLogger(logger.getName());
+        java.util.logging.Logger julLogger = java.util.logging.Logger.getLogger(this.logger.getName());
         this.api = new PointsAPI(url, username, password, julLogger, debug);
         this.commandsEnabled = Boolean.parseBoolean(String.valueOf(config.getOrDefault("commands", true)));
     }

--- a/paper/src/main/java/ch/ksrminecraft/akzuwoRankAPIPlaceholder/paper/AkzuwoRankAPIPaper.java
+++ b/paper/src/main/java/ch/ksrminecraft/akzuwoRankAPIPlaceholder/paper/AkzuwoRankAPIPaper.java
@@ -12,14 +12,17 @@ import org.slf4j.LoggerFactory;
 
 public class AkzuwoRankAPIPaper extends JavaPlugin {
 
+    private final Logger logger;
     private RankAPI rankAPI;
-    private Logger logger;
     private int announceTask;
+
+    public AkzuwoRankAPIPaper() {
+        this.logger = LoggerFactory.getLogger(AkzuwoRankAPIPaper.class);
+    }
 
     @Override
     public void onEnable() {
         saveDefaultConfig();
-        logger = LoggerFactory.getLogger(getLogger().getName());
         try {
             rankAPI = new RankAPI(getDataFolder().toPath(), logger);
         } catch (Exception e) {

--- a/velocity/src/main/java/ch/ksrminecraft/akzuwoRankAPIPlaceholder/AkzuwoRankAPIPlaceholder.java
+++ b/velocity/src/main/java/ch/ksrminecraft/akzuwoRankAPIPlaceholder/AkzuwoRankAPIPlaceholder.java
@@ -9,7 +9,6 @@ import com.velocitypowered.api.plugin.Plugin;
 import com.velocitypowered.api.plugin.annotation.DataDirectory;
 import com.velocitypowered.api.proxy.ProxyServer;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -19,12 +18,13 @@ public class AkzuwoRankAPIPlaceholder {
 
     private final ProxyServer server;
     private final Path dataDirectory;
-    private final Logger logger = LoggerFactory.getLogger(AkzuwoRankAPIPlaceholder.class);
+    private final Logger logger;
     private RankAPI rankAPI;
 
     @Inject
-    public AkzuwoRankAPIPlaceholder(ProxyServer server, @DataDirectory Path dataDirectory) {
+    public AkzuwoRankAPIPlaceholder(ProxyServer server, Logger logger, @DataDirectory Path dataDirectory) {
         this.server = server;
+        this.logger = logger;
         this.dataDirectory = dataDirectory;
     }
 


### PR DESCRIPTION
## Summary
- inject and store logger in `RankAPI`
- initialize logger via constructor in Paper module
- inject logger via constructor in Velocity module

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact from repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_6851a077d7108325bbbdf92049cb4a18