### PR TITLE
Configure Shade plugin for unified jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,12 +3,25 @@
   <groupId>ch.ksrminecraft</groupId>
   <artifactId>AkzuwoRankAPIPlaceholder</artifactId>
   <version>1.1</version>
-  <packaging>pom</packaging>
+  <packaging>jar</packaging>
   <modules>
     <module>common</module>
     <module>velocity</module>
     <module>paper</module>
   </modules>
+
+  <dependencies>
+    <dependency>
+      <groupId>ch.ksrminecraft</groupId>
+      <artifactId>velocity</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>ch.ksrminecraft</groupId>
+      <artifactId>paper</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
   <properties>
     <java.version>17</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -31,4 +44,25 @@
       <url>https://repo.papermc.io/repository/maven-public/</url>
     </repository>
   </repositories>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.5.1</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>


### PR DESCRIPTION
## Summary
- package parent module as a jar
- add dependencies on `paper` and `velocity` modules
- configure the Maven Shade plugin to build a single jar with all modules

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851a2f08c9c83259398a969d2bf0cf7