### PR TITLE
Add shaded all module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+# AkzuwoRankAPIPlaceholder
+
+Run `mvn clean package` from the project root to build all modules.
+The combined jar produced by the `all` module will appear under `all/target/`.

--- a/all/pom.xml
+++ b/all/pom.xml
@@ -1,0 +1,42 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>ch.ksrminecraft</groupId>
+    <artifactId>AkzuwoRankAPIPlaceholder</artifactId>
+    <version>1.1</version>
+  </parent>
+  <artifactId>all</artifactId>
+  <dependencies>
+    <dependency>
+      <groupId>ch.ksrminecraft</groupId>
+      <artifactId>paper</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>ch.ksrminecraft</groupId>
+      <artifactId>velocity</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.5.1</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,25 +3,13 @@
   <groupId>ch.ksrminecraft</groupId>
   <artifactId>AkzuwoRankAPIPlaceholder</artifactId>
   <version>1.1</version>
-  <packaging>jar</packaging>
+  <packaging>pom</packaging>
   <modules>
     <module>common</module>
     <module>velocity</module>
     <module>paper</module>
+    <module>all</module>
   </modules>
-
-  <dependencies>
-    <dependency>
-      <groupId>ch.ksrminecraft</groupId>
-      <artifactId>velocity</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>ch.ksrminecraft</groupId>
-      <artifactId>paper</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-  </dependencies>
   <properties>
     <java.version>17</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -45,24 +33,5 @@
     </repository>
   </repositories>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
-        <version>3.5.1</version>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>shade</goal>
-            </goals>
-            <configuration>
-              <createDependencyReducedPom>false</createDependencyReducedPom>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
+  
 </project>


### PR DESCRIPTION
## Summary
- change root to aggregator `pom`
- add new `all` module that shades `paper` and `velocity`
- document how to build combined jar

## Testing
- `apt-get update`
- `apt-get install -y maven`
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_6851a5ac9ef483258b74271fdba64142