### PR TITLE
Use Maven version in plugin

### DIFF
--- a/paper/pom.xml
+++ b/paper/pom.xml
@@ -32,6 +32,12 @@
     </dependency>
   </dependencies>
   <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/velocity/pom.xml
+++ b/velocity/pom.xml
@@ -20,7 +20,55 @@
     </dependency>
   </dependencies>
   <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <version>3.3.1</version>
+        <executions>
+          <execution>
+            <id>filter-build-constants</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/generated-sources/build-constants</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>src/main/java-template</directory>
+                  <filtering>true</filtering>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>3.5.0</version>
+        <executions>
+          <execution>
+            <id>add-source</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>${project.build.directory}/generated-sources/build-constants</source>
+              </sources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>

--- a/velocity/src/main/java-template/ch/ksrminecraft/akzuwoRankAPIPlaceholder/BuildConstants.java
+++ b/velocity/src/main/java-template/ch/ksrminecraft/akzuwoRankAPIPlaceholder/BuildConstants.java
@@ -1,0 +1,6 @@
+package ch.ksrminecraft.akzuwoRankAPIPlaceholder;
+
+public final class BuildConstants {
+    public static final String VERSION = "${project.version}";
+    private BuildConstants() {}
+}

--- a/velocity/src/main/java/ch/ksrminecraft/akzuwoRankAPIPlaceholder/AkzuwoRankAPIPlaceholder.java
+++ b/velocity/src/main/java/ch/ksrminecraft/akzuwoRankAPIPlaceholder/AkzuwoRankAPIPlaceholder.java
@@ -8,12 +8,13 @@ import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
 import com.velocitypowered.api.plugin.Plugin;
 import com.velocitypowered.api.plugin.annotation.DataDirectory;
 import com.velocitypowered.api.proxy.ProxyServer;
+import ch.ksrminecraft.akzuwoRankAPIPlaceholder.BuildConstants;
 import org.slf4j.Logger;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-@Plugin(id = "akzuwoextension", name = "AkzuwoRankAPIPlaceholder", version = "1.0")
+@Plugin(id = "akzuwoextension", name = "AkzuwoRankAPIPlaceholder", version = BuildConstants.VERSION)
 public class AkzuwoRankAPIPlaceholder {
 
     private final ProxyServer server;


### PR DESCRIPTION
## Summary
- create `BuildConstants.java` template containing `${project.version}`
- use `BuildConstants.VERSION` in the Velocity plugin annotation
- enable resource filtering for Velocity and Paper modules
- generate `BuildConstants` with Maven plugins

## Testing
- `mvn -q -DskipTests install` *(fails: aggregator pom has invalid packaging)*

------
https://chatgpt.com/codex/tasks/task_e_6851a5a93e3483258b685b1844c99408